### PR TITLE
#2 Location filtering bugfix, persistence adjustments

### DIFF
--- a/api/src/main/java/si/ape/location/api/v1/LocationApplication.java
+++ b/api/src/main/java/si/ape/location/api/v1/LocationApplication.java
@@ -11,8 +11,8 @@ import org.eclipse.microprofile.openapi.annotations.info.License;
 import org.eclipse.microprofile.openapi.annotations.servers.Server;
 
 @OpenAPIDefinition(info = @Info(title = "Location API", version = "v1",
-        contact = @Contact(email = "rso@fri.uni-lj.si"),
-        license = @License(name = "dev"), description = "API for managing locations."),
+        contact = @Contact(email = "ls6727@student.uni-lj.si, js1471@student.uni-lj.si"),
+        license = @License(name = "dev"), description = "API for managing the locations supported by APE."),
         servers = @Server(url = "http://localhost:8080/"))
 @ApplicationPath("/v1")
 public class LocationApplication extends Application {

--- a/models/src/main/resources/META-INF/persistence.xml
+++ b/models/src/main/resources/META-INF/persistence.xml
@@ -3,9 +3,6 @@
     <persistence-unit name="ape-location-jpa" transaction-type="RESOURCE_LOCAL">
         <non-jta-data-source>jdbc/APELocationDS</non-jta-data-source>
 
-        <!--<class>si.ape.location.models.entities.ImageMetadataEntity</class>
-        <class>si.ape.location.models.converters.InstantAtributeConverter</class>-->
-
         <class>si.ape.location.models.entities.CountryEntity</class>
         <class>si.ape.location.models.entities.CityEntity</class>
         <class>si.ape.location.models.entities.StreetEntity</class>
@@ -16,11 +13,11 @@
 
 
         <properties>
-            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
-            <property name="javax.persistence.schema-generation.create-source" value="metadata"/>
-            <property name="javax.persistence.sql-load-script-source"
-                      value="sql-scripts/init.sql" />
-            <property name="javax.persistence.schema-generation.drop-source" value="metadata"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.use_sql_comments" value="true"/>
+            <property name="hibernate.generate_statistics" value="true"/>
+            <property name="hibernate.default_schema" value="APE"/>
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
Fixed the bug that occurred during filtering by location name, that caused the location filtering to always return all elements. Additionally, modified the persistence.xml file so it doesn't try to recreate the schema and insert image data.